### PR TITLE
Implement web UI for stream config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# V2gogoLiveTrans
+
+This project captures RTSP streams and converts them to GIF images. A simple web interface allows management of stream addresses stored in an SQLite database.
+
+## Usage
+
+Install dependencies (requires Node.js and npm):
+
+```bash
+npm install
+```
+
+Start the web interface:
+
+```bash
+npm start
+```
+
+The application will be available at `http://localhost:3000/`. From there you can add, edit or remove stream entries which will be stored in `streams.db`.

--- a/db.js
+++ b/db.js
@@ -1,0 +1,17 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.join(__dirname, 'streams.db');
+const db = new sqlite3.Database(dbPath);
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS streams (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code TEXT UNIQUE,
+    address TEXT,
+    lon TEXT,
+    lat TEXT
+  )`);
+});
+
+module.exports = db;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "v2gogo-live-trans",
+  "version": "1.0.0",
+  "description": "RTSP stream capture and upload with web UI",
+  "main": "web.js",
+  "scripts": {
+    "start": "node web.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6",
+    "ejs": "^3.1.9"
+  }
+}

--- a/views/form.ejs
+++ b/views/form.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title><%= stream.id ? 'Edit' : 'Add' %> Stream</title>
+</head>
+<body>
+<h1><%= stream.id ? 'Edit' : 'Add' %> Stream</h1>
+<form method="post" action="<%= stream.id ? ('/edit/' + stream.id) : '/add' %>">
+    <label>Code:</label>
+    <input type="text" name="code" value="<%= stream.code || '' %>" required><br>
+    <label>Address:</label>
+    <input type="text" name="address" value="<%= stream.address || '' %>" ><br>
+    <label>Lon:</label>
+    <input type="text" name="lon" value="<%= stream.lon || '' %>" ><br>
+    <label>Lat:</label>
+    <input type="text" name="lat" value="<%= stream.lat || '' %>" ><br>
+    <button type="submit">Save</button>
+</form>
+<a href="/">Back</a>
+</body>
+</html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Streams</title>
+</head>
+<body>
+<h1>Stream List</h1>
+<a href="/add">Add Stream</a>
+<table border="1">
+<tr><th>ID</th><th>Code</th><th>Address</th><th>Actions</th></tr>
+<% streams.forEach(function(s){ %>
+<tr>
+<td><%= s.id %></td>
+<td><%= s.code %></td>
+<td><%= s.address %></td>
+<td>
+    <a href="/edit/<%= s.id %>">Edit</a>
+    <form action="/delete/<%= s.id %>" method="post" style="display:inline;">
+        <button type="submit">Delete</button>
+    </form>
+</td>
+</tr>
+<% }) %>
+</table>
+</body>
+</html>

--- a/web.js
+++ b/web.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const path = require('path');
+const db = require('./db');
+const { mkGif, start } = require('./server');
+
+const app = express();
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+app.use(express.urlencoded({ extended: true }));
+app.use('/sync', express.static(path.join(__dirname, 'sync')));
+
+app.get('/', (req, res) => {
+  db.all('SELECT * FROM streams ORDER BY id', (err, rows) => {
+    if (err) rows = [];
+    res.render('index', { streams: rows });
+  });
+});
+
+app.get('/add', (req, res) => {
+  res.render('form', { stream: {} });
+});
+
+app.post('/add', (req, res) => {
+  const { code, address, lon, lat } = req.body;
+  db.run('INSERT INTO streams(code,address,lon,lat) VALUES(?,?,?,?)', [code, address, lon, lat], () => {
+    res.redirect('/');
+  });
+});
+
+app.get('/edit/:id', (req, res) => {
+  const id = req.params.id;
+  db.get('SELECT * FROM streams WHERE id=?', [id], (err, row) => {
+    res.render('form', { stream: row });
+  });
+});
+
+app.post('/edit/:id', (req, res) => {
+  const id = req.params.id;
+  const { code, address, lon, lat } = req.body;
+  db.run('UPDATE streams SET code=?, address=?, lon=?, lat=? WHERE id=?', [code, address, lon, lat, id], () => {
+    res.redirect('/');
+  });
+});
+
+app.post('/delete/:id', (req, res) => {
+  const id = req.params.id;
+  db.run('DELETE FROM streams WHERE id=?', [id], () => {
+    res.redirect('/');
+  });
+});
+
+const timer = start();
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Web UI running on port ${port}`));


### PR DESCRIPTION
## Summary
- add Express-based web UI backed by SQLite
- convert server.js to read stream codes from SQLite
- document installation and usage

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node web.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684112749d5c8328b87c25a6765ce0fb